### PR TITLE
Modifying code to compile on Linux for gcc

### DIFF
--- a/Makefile.tflite
+++ b/Makefile.tflite
@@ -1,7 +1,7 @@
 NAME = edge-impulse-standalone
 
-CC = clang
-CXX = clang++
+CC = gcc
+CXX = g++
 CFLAGS ?= -Wall
 
 MACROS += -DTF_LITE_DISABLE_X86_NEON
@@ -25,7 +25,7 @@ CFLAGS += -Iedge-impulse-sdk/classifier
 CFLAGS += -Iedge-impulse-sdk/dsp
 CFLAGS += -Iedge-impulse-sdk/dsp/kissfft
 CFLAGS += -Iedge-impulse-sdk/porting
-CFLAGS += -lc++
+CFLAGS += -lstdc++
 CFLAGS += -lm
 
 all: build


### PR DESCRIPTION
Small changes required to compile, may just be due to environment in which code was compiled.

Code was compiled in a Linux machine using gcc with `-std=c++11`.